### PR TITLE
[TwigHooks] Allow discarding hookable's context

### DIFF
--- a/src/TwigHooks/src/Twig/Node/HookNode.php
+++ b/src/TwigHooks/src/Twig/Node/HookNode.php
@@ -14,6 +14,7 @@ final class HookNode extends Node
     public function __construct (
         Node $name,
         ?Node $context,
+        bool $only,
         int $lineno,
         string $tag = null
     ) {
@@ -22,7 +23,9 @@ final class HookNode extends Node
                 'name' => $name,
                 'hook_level_context' => $context ?? new ArrayExpression([], $lineno),
             ],
-            [],
+            [
+                'only' => $only,
+            ],
             $lineno,
             $tag,
         );
@@ -43,6 +46,8 @@ final class HookNode extends Node
         $compiler->subcompile($this->getNode('hook_level_context'));
         $compiler->raw(', ');
         $compiler->raw('$context["hookable_metadata"] ?? null');
+        $compiler->raw(', ');
+        $compiler->raw($this->getAttribute('only') ? 'true' : 'false');
         $compiler->raw(");\n");
     }
 }

--- a/src/TwigHooks/src/Twig/Runtime/HooksRuntime.php
+++ b/src/TwigHooks/src/Twig/Runtime/HooksRuntime.php
@@ -59,11 +59,16 @@ final class HooksRuntime implements RuntimeExtensionInterface
      * @param string|array<string> $hookNames
      * @param array<string, mixed> $hookContext
      */
-    public function renderHook(string|array $hookNames, array $hookContext = [], ?HookableMetadata $hookableMetadata = null): string
+    public function renderHook(
+        string|array $hookNames,
+        array $hookContext = [],
+        ?HookableMetadata $hookableMetadata = null,
+        bool $only = false,
+    ): string
     {
         $hookNames = is_string($hookNames) ? [$hookNames] : $hookNames;
 
-        $context = $this->getContext($hookContext, $hookableMetadata);
+        $context = $this->getContext($hookContext, $hookableMetadata, $only);
         $prefixes = $this->getPrefixes($hookContext, $hookableMetadata);
 
         if (false === $this->enableAutoprefixing || [] === $prefixes) {
@@ -105,13 +110,13 @@ final class HooksRuntime implements RuntimeExtensionInterface
      * @param array<string, mixed> $hookContext
      * @return array<string, mixed>
      */
-    private function getContext(array $hookContext, ?HookableMetadata $hookableMetadata): array
+    private function getContext(array $hookContext, ?HookableMetadata $hookableMetadata, bool $only = false): array
     {
-        $context = [];
-
-        if ($hookableMetadata !== null) {
-            $context = $hookableMetadata->context->all();
+        if ($only) {
+            return $hookContext;
         }
+
+        $context = $hookableMetadata?->context->all() ?? [];
 
         return array_merge($context, $hookContext);
     }

--- a/src/TwigHooks/src/Twig/TokenParser/HookTokenParser.php
+++ b/src/TwigHooks/src/Twig/TokenParser/HookTokenParser.php
@@ -24,9 +24,14 @@ final class HookTokenParser extends AbstractTokenParser
             $hookContext = $this->parser->getExpressionParser()->parseMultitargetExpression();
         }
 
+        $only = false;
+        if ($stream->nextIf(Token::NAME_TYPE, 'only')) {
+            $only = true;
+        }
+
         $stream->expect(Token::BLOCK_END_TYPE);
 
-        return new HookNode($hooksNames, $hookContext, $lineno, $this->getTag());
+        return new HookNode($hooksNames, $hookContext, $only, $lineno, $this->getTag());
     }
 
     public function getTag(): string

--- a/src/TwigHooks/tests/Functional/.application/config/packages/twig_hooks.yaml
+++ b/src/TwigHooks/tests/Functional/.application/config/packages/twig_hooks.yaml
@@ -3,3 +3,21 @@ twig_hooks:
         'hook_with_hookable':
             hookable:
                 template: 'parsing_hook_tag_test/hook_with_hookables/hookable_with_hook.html.twig'
+
+        'restricting_context_scope.index':
+            with_only:
+                template: 'restricting_context_scope/index/with_only.html.twig'
+                context:
+                    'other': 'data'
+            without_only:
+                template: 'restricting_context_scope/index/without_only.html.twig'
+                context:
+                    'other': 'data'
+
+        'restricting_context_scope.index.with_only':
+            some:
+                template: 'restricting_context_scope/index/block/some.html.twig'
+
+        'restricting_context_scope.index.without_only':
+            some:
+                template: 'restricting_context_scope/index/block/some.html.twig'

--- a/src/TwigHooks/tests/Functional/.application/templates/restricting_context_scope/index.html.twig
+++ b/src/TwigHooks/tests/Functional/.application/templates/restricting_context_scope/index.html.twig
@@ -1,0 +1,3 @@
+{% hook 'restricting_context_scope.index' with {
+    some: 'data',
+} %}

--- a/src/TwigHooks/tests/Functional/.application/templates/restricting_context_scope/index/block/some.html.twig
+++ b/src/TwigHooks/tests/Functional/.application/templates/restricting_context_scope/index/block/some.html.twig
@@ -1,0 +1,6 @@
+{% set hookable_context = get_hookable_context() %}
+
+{{ hookable_context.get('title') }}
+
+is "some" defined: {{ hookable_context.has('some') ? 'Yes' : 'No' }}
+is "other" defined: {{ hookable_context.has('other') ? 'Yes' : 'No' }}

--- a/src/TwigHooks/tests/Functional/.application/templates/restricting_context_scope/index/with_only.html.twig
+++ b/src/TwigHooks/tests/Functional/.application/templates/restricting_context_scope/index/with_only.html.twig
@@ -1,0 +1,3 @@
+{% hook 'with_only' with {
+    title: 'Only',
+} only %}

--- a/src/TwigHooks/tests/Functional/.application/templates/restricting_context_scope/index/without_only.html.twig
+++ b/src/TwigHooks/tests/Functional/.application/templates/restricting_context_scope/index/without_only.html.twig
@@ -1,0 +1,3 @@
+{% hook 'without_only' with {
+    title: 'Without only',
+} %}

--- a/src/TwigHooks/tests/Functional/Twig/RestrictingContextScopeTest.php
+++ b/src/TwigHooks/tests/Functional/Twig/RestrictingContextScopeTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Functional\Twig;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment as Twig;
+
+/**
+ * @group kernel-required
+ */
+final class RestrictingContextScopeTest extends KernelTestCase
+{
+    public function testItRendersSingleHookName(): void
+    {
+        $this->assertSame(
+            <<<EXPECTED
+            <!-- BEGIN HOOK | name: "restricting_context_scope.index" -->
+            <!-- BEGIN HOOKABLE | hook: "restricting_context_scope.index", type: "template", name: "with_only", target: "restricting_context_scope/index/with_only.html.twig", priority: 0 -->
+            <!-- BEGIN HOOK | name: "restricting_context_scope.index.with_only" -->
+            <!-- BEGIN HOOKABLE | hook: "restricting_context_scope.index.with_only", type: "template", name: "some", target: "restricting_context_scope/index/block/some.html.twig", priority: 0 -->
+            Only
+            
+            is "some" defined: No
+            is "other" defined: No
+            <!--  END HOOKABLE  | hook: "restricting_context_scope.index.with_only", type: "template", name: "some", target: "restricting_context_scope/index/block/some.html.twig", priority: 0 -->
+            <!--  END HOOK  | name: "restricting_context_scope.index.with_only" -->
+            <!--  END HOOKABLE  | hook: "restricting_context_scope.index", type: "template", name: "with_only", target: "restricting_context_scope/index/with_only.html.twig", priority: 0 -->
+            <!-- BEGIN HOOKABLE | hook: "restricting_context_scope.index", type: "template", name: "without_only", target: "restricting_context_scope/index/without_only.html.twig", priority: 0 -->
+            <!-- BEGIN HOOK | name: "restricting_context_scope.index.without_only" -->
+            <!-- BEGIN HOOKABLE | hook: "restricting_context_scope.index.without_only", type: "template", name: "some", target: "restricting_context_scope/index/block/some.html.twig", priority: 0 -->
+            Without only
+            
+            is "some" defined: Yes
+            is "other" defined: Yes
+            <!--  END HOOKABLE  | hook: "restricting_context_scope.index.without_only", type: "template", name: "some", target: "restricting_context_scope/index/block/some.html.twig", priority: 0 -->
+            <!--  END HOOK  | name: "restricting_context_scope.index.without_only" -->
+            <!--  END HOOKABLE  | hook: "restricting_context_scope.index", type: "template", name: "without_only", target: "restricting_context_scope/index/without_only.html.twig", priority: 0 -->
+            <!--  END HOOK  | name: "restricting_context_scope.index" -->
+            EXPECTED,
+            $this->render('restricting_context_scope/index.html.twig'),
+        );
+    }
+
+    private function render(string $path): string
+    {
+        /** @var Twig $twig */
+        $twig = $this->getContainer()->get('twig');
+
+        return $twig->render($path);
+    }
+}


### PR DESCRIPTION
Currently, automatically we merge the hookable-level context with the hook-level context. So data provided in the entry template is automatically passed down to the most bottom hookable.

In order to prevent this behavior, while declaring a new hook, we are able to add the `only` keyword, which will disable this mechanism. In such case, only the data from the `with` keyword will be passed down.

Example:
```
{% hook 'content' with {
	title: 'some title',
} only %}
```