### PR TITLE
Fix Hooks runtime (again)

### DIFF
--- a/src/TwigHooks/src/Twig/Runtime/HooksRuntime.php
+++ b/src/TwigHooks/src/Twig/Runtime/HooksRuntime.php
@@ -152,6 +152,6 @@ final class HooksRuntime implements RuntimeExtensionInterface
 
         $context = $hookableMetadata?->context->all() ?? [];
 
-        return array_merge($context, $twigVars, $hookContext);
+        return array_merge($twigVars, $context, $hookContext);
     }
 }


### PR DESCRIPTION
@diimpp You was right, twig vars seems to be first, this is too dangerous and it breaks some shop pages.