### PR TITLE
Use current Twig vars on HooksRuntime when no only option has been pa…

### DIFF
--- a/src/TwigHooks/src/Twig/Node/HookNode.php
+++ b/src/TwigHooks/src/Twig/Node/HookNode.php
@@ -54,7 +54,7 @@ final class HookNode extends Node
         $compiler->raw(', ');
         $compiler->subcompile($this->getNode('hook_level_context'));
         $compiler->raw(', ');
-        $compiler->raw('$context["hookable_metadata"] ?? null');
+        $compiler->raw('$context');
         $compiler->raw(', ');
         $compiler->raw($this->getAttribute('only') ? 'true' : 'false');
         $compiler->raw(");\n");

--- a/src/TwigHooks/src/Twig/Runtime/HooksRuntime.php
+++ b/src/TwigHooks/src/Twig/Runtime/HooksRuntime.php
@@ -21,6 +21,7 @@ use Sylius\TwigHooks\Hook\Renderer\HookRendererInterface;
 use Sylius\TwigHooks\Hookable\Metadata\HookableMetadata;
 use Twig\Error\RuntimeError;
 use Twig\Extension\RuntimeExtensionInterface;
+use Webmozart\Assert\Assert;
 
 final class HooksRuntime implements RuntimeExtensionInterface
 {
@@ -80,18 +81,23 @@ final class HooksRuntime implements RuntimeExtensionInterface
 
     /**
      * @param string|array<string> $hookNames
+     * @param array<string, mixed> $twigVars
      * @param array<string, mixed> $hookContext
      */
     public function renderHook(
         string|array $hookNames,
         array $hookContext = [],
-        ?HookableMetadata $hookableMetadata = null,
+        array $twigVars = [],
         bool $only = false,
     ): string {
         $hookNames = is_string($hookNames) ? [$hookNames] : $hookNames;
         $hookNames = array_map([$this->nameNormalizer, 'normalize'], $hookNames);
 
-        $context = $this->getContext($hookContext, $hookableMetadata, $only);
+        $hookableMetadata = $twigVars[self::HOOKABLE_METADATA] ?? null;
+        Assert::nullOrIsInstanceOf($hookableMetadata, HookableMetadata::class);
+        unset($twigVars[self::HOOKABLE_METADATA]);
+
+        $context = $this->getContext($hookContext, $twigVars, $hookableMetadata, $only);
         $prefixes = $this->getPrefixes($hookContext, $hookableMetadata);
 
         if (false === $this->enableAutoprefixing || [] === $prefixes) {
@@ -134,10 +140,11 @@ final class HooksRuntime implements RuntimeExtensionInterface
 
     /**
      * @param array<string, mixed> $hookContext
+     * @param array<string, mixed> $twigVars
      *
      * @return array<string, mixed>
      */
-    private function getContext(array $hookContext, ?HookableMetadata $hookableMetadata, bool $only = false): array
+    private function getContext(array $hookContext, array $twigVars, ?HookableMetadata $hookableMetadata, bool $only = false): array
     {
         if ($only) {
             return $hookContext;
@@ -145,6 +152,6 @@ final class HooksRuntime implements RuntimeExtensionInterface
 
         $context = $hookableMetadata?->context->all() ?? [];
 
-        return array_merge($context, $hookContext);
+        return array_merge($twigVars, $context, $hookContext);
     }
 }

--- a/src/TwigHooks/tests/Functional/.application/templates/restricting_context_scope/index/block/some.html.twig
+++ b/src/TwigHooks/tests/Functional/.application/templates/restricting_context_scope/index/block/some.html.twig
@@ -4,3 +4,4 @@
 
 is "some" defined: {{ hookable_context.has('some') ? 'Yes' : 'No' }}
 is "other" defined: {{ hookable_context.has('other') ? 'Yes' : 'No' }}
+is "var in template" defined: {{ hookable_context.has('var_in_template') ? 'Yes' : 'No' }}

--- a/src/TwigHooks/tests/Functional/Twig/RestrictingContextScopeTest.php
+++ b/src/TwigHooks/tests/Functional/Twig/RestrictingContextScopeTest.php
@@ -33,6 +33,7 @@ final class RestrictingContextScopeTest extends KernelTestCase
             
             is "some" defined: No
             is "other" defined: No
+            is "var in template" defined: No
             <!--  END HOOKABLE  | hook: "restricting_context_scope.index.with_only", name: "some", template: "restricting_context_scope/index/block/some.html.twig", priority: 0 -->
             <!--  END HOOK  | name: "restricting_context_scope.index.with_only" -->
             <!--  END HOOKABLE  | hook: "restricting_context_scope.index", name: "with_only", template: "restricting_context_scope/index/with_only.html.twig", priority: 0 -->
@@ -43,6 +44,7 @@ final class RestrictingContextScopeTest extends KernelTestCase
             
             is "some" defined: Yes
             is "other" defined: Yes
+            is "var in template" defined: Yes
             <!--  END HOOKABLE  | hook: "restricting_context_scope.index.without_only", name: "some", template: "restricting_context_scope/index/block/some.html.twig", priority: 0 -->
             <!--  END HOOK  | name: "restricting_context_scope.index.without_only" -->
             <!--  END HOOKABLE  | hook: "restricting_context_scope.index", name: "without_only", template: "restricting_context_scope/index/without_only.html.twig", priority: 0 -->


### PR DESCRIPTION
…ssed

Redo the changes reverted here
https://github.com/Sylius/Stack/pull/72

We will release that on 0.5 (next release).  That means we'll not break Sylius shop, until we allow Twig Hooks "^0.5".
I've created a 0.4 branch to release our 0.4.1.

From my investigation, I've managed to fix one issue on Shop.

```twig
<!-- ShopBundle/templates/checkout/address/form/addresses/address/form.html.twig -->

{% hook 'address' with { _prefixes: prefixes, 'form': attribute(form, field) } only %}
```
