### PR TITLE
[Docs] Fix Twig blocks

### DIFF
--- a/docs/cookbook/admin_panel/index.md
+++ b/docs/cookbook/admin_panel/index.md
@@ -42,9 +42,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 ```
 
 ```twig
+{% raw %}
 {# templates/shared/crud/common/sidebar/logo/image.html.twig #}
 
 <img src="{{ asset('images/logo.png') }}" alt="Your Brand name" class="navbar-brand-image" />
+{% endraw %}
   
 ```
 
@@ -71,7 +73,7 @@ sylius_twig_hooks:
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import('@SyliusBootstrapAdminUiBundle/config/app.php');
+    // ...
 
     // Add these following lines to define your own Twig template for the logo.
     $containerConfigurator->extension('sylius_twig_hooks', [
@@ -88,8 +90,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 ```
 
 ```twig
+{% raw %}
 <img src="{{ asset('images/logo.png') }}" alt="Your Brand name" class="sylius navbar-brand-image">
-
+{% endraw %}
 ```
 
 ## How to customize the admin menu

--- a/docs/twig-extra/getting-started.md
+++ b/docs/twig-extra/getting-started.md
@@ -30,11 +30,13 @@ $books = [new Book('Shinning'), new Book('A Lord Of The Rings')];
 ```
 
 ```twig
+{% raw %}
 <ul>
 {% for book in books|sort_by('name') %}
     <li>{{ book.name }}</li>
 {% endif %}
 </ul>
+{% endraw %}
 ```
 
 ```text
@@ -52,11 +54,13 @@ $books = [['name' => 'Shinning'], ['name' => 'A Lord Of The Rings']];
 You just need to encapsulate the key with `[]`.
 
 ```twig
+{% raw %}
 <ul>
 {% for book in books|sort_by('[name]') %}
     <li>{{ book.name }}</li>
 {% endif %}
 </ul>
+{% endraw %}
 ```
 
 ### Test HTML attribute


### PR DESCRIPTION
I miss the "raw" to make the Twig markdown works on Gitbook

Example 
https://github.com/Sylius/Sylius/blob/9d605c5d5f1a6e01c2a2a14960c62b7b047ff9dd/docs/the-customization-guide/customizing-templates.md?plain=1#L48-L73

Results
https://docs.sylius.com/the-customization-guide/customizing-templates#customizing-templates-via-overriding