### PR TITLE
[TwigHooks] Mark Debug Info With Different Colors For Templates And Components

### DIFF
--- a/src/TwigHooks/src/Profiler/Dumper/HtmlDumper.php
+++ b/src/TwigHooks/src/Profiler/Dumper/HtmlDumper.php
@@ -67,8 +67,9 @@ final class HtmlDumper
         };
 
         $str = sprintf(
-            '%s└ <span><span class="status-success">(%s)</span> [↑ %d, ⏲ %d ms] %s (%s)</span>',
+            '%s└ <span><span class="%s">(%s)</span> [↑ %d, ⏲ %d ms] %s (%s)</span>',
             $prefix,
+            $targetName === 'Template' ? 'status-success' : 'status-warning',
             $targetName,
             $hookableProfile->getHookable()->priority(),
             $hookableProfile->getDuration(),


### PR DESCRIPTION
Before:
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/5070d81c-1307-4337-a6e9-d3386afd1900">

After:
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/921a35c1-ab48-4275-bfd3-8a89245e4142">
