### PR TITLE
[BootstrapAdminUi] Remove pagination selector is there are no other limits

### DIFF
--- a/app/Grid/TalkGrid.php
+++ b/app/Grid/TalkGrid.php
@@ -44,6 +44,7 @@ final class TalkGrid extends AbstractGrid implements ResourceAwareGridInterface
     {
         $gridBuilder
             ->addOrderBy('startsAt')
+            ->setLimits([10, 25, 50])
             ->addFilter(
                 EntityFilter::create('conference', Conference::class)
                     ->setLabel('app.ui.conference')

--- a/src/BootstrapAdminUi/templates/shared/helper/pagination.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/helper/pagination.html.twig
@@ -11,15 +11,19 @@
 {% endmacro %}
 
 {% macro number_of_results_selector(paginator, pagination_limits) %}
-    <div class="dropdown">
-        <button type="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
-            {{ 'sylius.ui.show'|trans }} {{ paginator.maxPerPage }}
-        </button>
-        <div class="dropdown-menu dropdown-menu-end ">
-            {% for limit in pagination_limits|filter(limit => limit != paginator.maxPerPage) %}
-                {% set path = path(app.request.attributes.get('_route'), app.request.attributes.all('_route_params')|merge(app.request.query)|merge({'limit': limit})) %}
-                <a class="dropdown-item" href="{{ path }}">{{ limit }}</a>
-            {% endfor %}
+    {% set other_pagination_limits = pagination_limits|filter(limit => limit != paginator.maxPerPage) %}
+
+    {% if other_pagination_limits is not empty %}
+        <div class="dropdown">
+            <button type="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
+                {{ 'sylius.ui.show'|trans }} {{ paginator.maxPerPage }}
+            </button>
+            <div class="dropdown-menu dropdown-menu-end ">
+                {% for limit in other_pagination_limits %}
+                    {% set path = path(app.request.attributes.get('_route'), app.request.attributes.all('_route_params')|merge(app.request.query)|merge({'limit': limit})) %}
+                    <a class="dropdown-item" href="{{ path }}">{{ limit }}</a>
+                {% endfor %}
+            </div>
         </div>
-    </div>
+    {% endif %}
 {% endmacro %}


### PR DESCRIPTION
**Before**
![image](https://github.com/user-attachments/assets/c951c6a4-6c25-4c6b-8c57-769c6ddece35)

**After**
![image](https://github.com/user-attachments/assets/9c540c76-15a3-4ce1-adfd-346e73fdb46e)

**And still ok with several available pagination limits.**
![image](https://github.com/user-attachments/assets/9999dd3f-ab7f-4541-99f5-4eb541492e9d)
