### PR TITLE
Fix form when we do not use any resource factory

### DIFF
--- a/src/BootstrapAdminUi/templates/shared/crud/common/content/form.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/crud/common/content/form.html.twig
@@ -3,7 +3,7 @@
 {% endif %}
 
 {% if resource is not defined %}
-    {% set resource = hookable_metadata.context.resource %}
+    {% set resource = hookable_metadata.context.resource|default(null) %}
 {% endif %}
 
 {% form_theme form '@SyliusBootstrapAdminUi/shared/form_theme.html.twig' %}


### PR DESCRIPTION
When we do not use any resource factory (eg: on resource detached from Doctrine), we have an error cause the resource is not defined.