### PR TITLE
[Doc] Fix bad wording in getting started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,7 @@ Type "a" or "p" to configure the packages via Symfony Flex.
 ### Install missing tom-select assets
 
 ```bash
-symfony console importmap:require tom-select/dist/css/tom-select.default.cs
+symfony console importmap:require tom-select/dist/css/tom-select.default.css
 ```
 
 ### Run your web server


### PR DESCRIPTION
Inside geting started documentation, the "Install missing tom-select assets" command is wrong, an "s" is missing at the end.