### PR TITLE
[TwigHooks] Template configuration provider with context

### DIFF
--- a/config/packages/sylius_twig_hooks.yaml
+++ b/config/packages/sylius_twig_hooks.yaml
@@ -17,6 +17,12 @@ sylius_twig_hooks:
             description:
                 template: 'book/index/content/header/description.html.twig'
 
+        'sylius_admin.book.show.content.header.title_block':
+            title:
+                template: '@SyliusBootstrapAdminUi/shared/crud/common/content/header/title_block/title.html.twig'
+                configuration:
+                    title: '@=_context.book.getTitle()'
+
         'sylius_admin.talk.create.content':
             form:
                 component: 'App\Twig\Component\TalkFormComponent'

--- a/src/TwigHooks/config/services.php
+++ b/src/TwigHooks/config/services.php
@@ -22,6 +22,9 @@ use Sylius\TwigHooks\Hookable\Metadata\HookableMetadataFactory;
 use Sylius\TwigHooks\Provider\ComponentPropsProvider;
 use Sylius\TwigHooks\Provider\DefaultConfigurationProvider;
 use Sylius\TwigHooks\Provider\DefaultContextProvider;
+use Sylius\TwigHooks\Provider\PropsProviderInterface;
+use Sylius\TwigHooks\Provider\TemplateConfigurationProvider;
+use Sylius\TwigHooks\Provider\TemplateConfigurationProviderInterface;
 use Sylius\TwigHooks\Registry\HookablesRegistry;
 use Sylius\TwigHooks\Twig\HooksExtension;
 use Sylius\TwigHooks\Twig\Runtime\HooksRuntime;
@@ -39,8 +42,16 @@ return static function (ContainerConfigurator $configurator): void {
             inline_service(ExpressionLanguage::class),
         ])
     ;
+    $services->alias(PropsProviderInterface::class, 'sylius_twig_hooks.provider.component_props');
 
     $services->set('sylius_twig_hooks.provider.default_configuration', DefaultConfigurationProvider::class);
+
+    $services->set('sylius_twig_hooks.provider.template_configuration', TemplateConfigurationProvider::class)
+        ->args([
+            inline_service(ExpressionLanguage::class),
+        ])
+    ;
+    $services->alias(TemplateConfigurationProviderInterface::class, 'sylius_twig_hooks.provider.template_configuration');
 
     $services->set('sylius_twig_hooks.registry.hookables', HookablesRegistry::class)
         ->args([

--- a/src/TwigHooks/config/services/hookable_renderer.php
+++ b/src/TwigHooks/config/services/hookable_renderer.php
@@ -40,6 +40,7 @@ return static function (ContainerConfigurator $configurator): void {
     $services->set('sylius_twig_hooks.renderer.hookable.template', HookableTemplateRenderer::class)
         ->args([
             service('twig'),
+            service('sylius_twig_hooks.provider.template_configuration'),
         ])
         ->tag('sylius_twig_hooks.hookable_renderer')
     ;

--- a/src/TwigHooks/src/Hookable/Metadata/HookableMetadata.php
+++ b/src/TwigHooks/src/Hookable/Metadata/HookableMetadata.php
@@ -39,4 +39,9 @@ class HookableMetadata
     {
         return count($this->prefixes) > 0;
     }
+
+    public function withConfiguration(ScalarDataBagInterface $configuration): self
+    {
+        return new self($this->renderedBy, $this->context, $configuration, $this->prefixes);
+    }
 }

--- a/src/TwigHooks/src/Hookable/Renderer/HookableTemplateRenderer.php
+++ b/src/TwigHooks/src/Hookable/Renderer/HookableTemplateRenderer.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\TwigHooks\Hookable\Renderer;
 
+use Sylius\TwigHooks\Bag\ScalarDataBag;
 use Sylius\TwigHooks\Hookable\AbstractHookable;
 use Sylius\TwigHooks\Hookable\HookableTemplate;
 use Sylius\TwigHooks\Hookable\Metadata\HookableMetadata;
 use Sylius\TwigHooks\Hookable\Renderer\Exception\HookRenderException;
+use Sylius\TwigHooks\Provider\TemplateConfigurationProviderInterface;
 use Sylius\TwigHooks\Twig\Runtime\HooksRuntime;
 use Twig\Environment as Twig;
 
@@ -24,6 +26,7 @@ final class HookableTemplateRenderer implements SupportableHookableRendererInter
 {
     public function __construct(
         private readonly Twig $twig,
+        private readonly TemplateConfigurationProviderInterface $configurationProvider,
     ) {
     }
 
@@ -39,6 +42,9 @@ final class HookableTemplateRenderer implements SupportableHookableRendererInter
         }
 
         try {
+            $configuration = $this->configurationProvider->provide($hookable, $metadata);
+            $metadata = $metadata->withConfiguration(new ScalarDataBag($configuration));
+
             return $this->twig->render($hookable->template, [
                 HooksRuntime::HOOKABLE_METADATA => $metadata,
             ]);

--- a/src/TwigHooks/src/Provider/TemplateConfigurationProvider.php
+++ b/src/TwigHooks/src/Provider/TemplateConfigurationProvider.php
@@ -21,7 +21,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 final class TemplateConfigurationProvider implements TemplateConfigurationProviderInterface
 {
     public function __construct(
-        private ExpressionLanguage $expressionLanguage,
+        private readonly ExpressionLanguage $expressionLanguage,
     ) {
     }
 

--- a/src/TwigHooks/src/Provider/TemplateConfigurationProvider.php
+++ b/src/TwigHooks/src/Provider/TemplateConfigurationProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\TwigHooks\Provider;
+
+use Sylius\TwigHooks\Hookable\HookableTemplate;
+use Sylius\TwigHooks\Hookable\Metadata\HookableMetadata;
+use Sylius\TwigHooks\Provider\Exception\InvalidExpressionException;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+final class TemplateConfigurationProvider implements TemplateConfigurationProviderInterface
+{
+    public function __construct(
+        private ExpressionLanguage $expressionLanguage,
+    ) {
+    }
+
+    public function provide(HookableTemplate $hookable, HookableMetadata $metadata): array
+    {
+        $values = [
+            '_context' => $metadata->context,
+        ];
+
+        return $this->mapArrayRecursively(function (mixed $value) use ($values, $hookable): mixed {
+            if (is_string($value) && str_starts_with($value, '@=')) {
+                try {
+                    return $this->expressionLanguage->evaluate(substr($value, 2), $values);
+                } catch (\Throwable $e) {
+                    throw new InvalidExpressionException(
+                        sprintf(
+                            'Failed to evaluate the "%s" expression while rendering the "%s" hookable in the "%s" hook. Error: %s".',
+                            $value,
+                            $hookable->name,
+                            $hookable->hookName,
+                            $e->getMessage(),
+                        ),
+                        previous: $e,
+                    );
+                }
+            }
+
+            return $value;
+        }, $hookable->configuration);
+    }
+
+    /**
+     * @param array<array-key, mixed> $array
+     *
+     * @return array<array-key, mixed>
+     */
+    private function mapArrayRecursively(callable $callback, array $array): array
+    {
+        $result = [];
+        foreach ($array as $key => $value) {
+            $result[$key] = is_array($value)
+                ? $this->mapArrayRecursively($callback, $value)
+                : $callback($value);
+        }
+
+        return $result;
+    }
+}

--- a/src/TwigHooks/src/Provider/TemplateConfigurationProviderInterface.php
+++ b/src/TwigHooks/src/Provider/TemplateConfigurationProviderInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\TwigHooks\Provider;
+
+use Sylius\TwigHooks\Hookable\HookableTemplate;
+use Sylius\TwigHooks\Hookable\Metadata\HookableMetadata;
+use Sylius\TwigHooks\Provider\Exception\InvalidExpressionException;
+
+interface TemplateConfigurationProviderInterface
+{
+    /**
+     * @throws InvalidExpressionException
+     *
+     * @return array<string, mixed>
+     */
+    public function provide(HookableTemplate $hookable, HookableMetadata $metadata): array;
+}

--- a/src/TwigHooks/tests/Unit/Hookable/Renderer/HookableTemplateRendererTest.php
+++ b/src/TwigHooks/tests/Unit/Hookable/Renderer/HookableTemplateRendererTest.php
@@ -18,7 +18,10 @@ use PHPUnit\Framework\TestCase;
 use Sylius\TwigHooks\Hookable\Metadata\HookableMetadata;
 use Sylius\TwigHooks\Hookable\Renderer\Exception\HookRenderException;
 use Sylius\TwigHooks\Hookable\Renderer\HookableTemplateRenderer;
+use Sylius\TwigHooks\Provider\TemplateConfigurationProvider;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Tests\Sylius\TwigHooks\Utils\MotherObject\HookableComponentMotherObject;
+use Tests\Sylius\TwigHooks\Utils\MotherObject\HookableMetadataMotherObject;
 use Tests\Sylius\TwigHooks\Utils\MotherObject\HookableTemplateMotherObject;
 use Twig\Environment as Twig;
 use Twig\Error\Error;
@@ -55,7 +58,7 @@ final class HookableTemplateRendererTest extends TestCase
 
     public function testItRendersHookableTemplate(): void
     {
-        $metadata = $this->createMock(HookableMetadata::class);
+        $metadata = HookableMetadataMotherObject::some();
 
         $this->twig->expects($this->once())->method('render')->with('some-template', [
             'hookable_metadata' => $metadata,
@@ -69,7 +72,7 @@ final class HookableTemplateRendererTest extends TestCase
 
     public function testItThrowsAnExceptionWhenTwigThrowsAnError(): void
     {
-        $metadata = $this->createMock(HookableMetadata::class);
+        $metadata = HookableMetadataMotherObject::some();
 
         $this->twig->expects($this->once())->method('render')->with('some-template', [
             'hookable_metadata' => $metadata,
@@ -78,13 +81,13 @@ final class HookableTemplateRendererTest extends TestCase
         $hookable = HookableTemplateMotherObject::withTarget('some-template');
 
         $this->expectException(HookRenderException::class);
-        $this->expectExceptionMessage('An error occurred during rendering the "some_name" hook in the "some_hook" hookable. Unable to find the template at line 76.');
+        $this->expectExceptionMessage('An error occurred during rendering the "some_name" hook in the "some_hook" hookable. Unable to find the template at line 79.');
 
         $this->getTestSubject()->render($hookable, $metadata);
     }
 
     private function getTestSubject(): HookableTemplateRenderer
     {
-        return new HookableTemplateRenderer($this->twig);
+        return new HookableTemplateRenderer($this->twig, new TemplateConfigurationProvider(new ExpressionLanguage()));
     }
 }

--- a/src/TwigHooks/tests/Unit/Provider/TemplatesConfigurationProviderTest.php
+++ b/src/TwigHooks/tests/Unit/Provider/TemplatesConfigurationProviderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\TwigHooks\Unit\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\TwigHooks\Provider\TemplateConfigurationProvider;
+use Sylius\TwigHooks\Provider\TemplateConfigurationProviderInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Tests\Sylius\TwigHooks\Utils\MotherObject\HookableMetadataMotherObject;
+use Tests\Sylius\TwigHooks\Utils\MotherObject\HookableTemplateMotherObject;
+
+final class TemplatesConfigurationProviderTest extends TestCase
+{
+    public function testItReturnsEmptyArrayWhenNoConfigurationDefined(): void
+    {
+        $hookable = HookableTemplateMotherObject::withConfiguration([]);
+        $metadata = HookableMetadataMotherObject::some();
+
+        $templateConfigurationProvider = $this->createTestSubject();
+
+        $this->assertSame([], $templateConfigurationProvider->provide($hookable, $metadata));
+    }
+
+    public function testItReturnsConfiguration(): void
+    {
+        $hookable = HookableTemplateMotherObject::withConfiguration(['message' => 'Hello, World!']);
+        $metadata = HookableMetadataMotherObject::some();
+
+        $templateConfigurationProvider = $this->createTestSubject();
+
+        $this->assertSame(['message' => 'Hello, World!'], $templateConfigurationProvider->provide($hookable, $metadata));
+    }
+
+    public function testItEvaluatesExpressions(): void
+    {
+        $hookable = HookableTemplateMotherObject::withConfiguration([
+            'username' => '@=_context.username',
+        ]);
+        $metadata = HookableMetadataMotherObject::withContext(
+            ['username' => 'Jacob'],
+        );
+
+        $templateConfigurationProvider = $this->createTestSubject();
+
+        $this->assertSame(['username' => 'Jacob'], $templateConfigurationProvider->provide($hookable, $metadata));
+    }
+
+    private function createTestSubject(): TemplateConfigurationProviderInterface
+    {
+        return new TemplateConfigurationProvider(new ExpressionLanguage());
+    }
+}

--- a/templates/book/show/content/page_body.html.twig
+++ b/templates/book/show/content/page_body.html.twig
@@ -3,11 +3,6 @@
 <div class="page-body">
     <div class="container-xl">
         <div class="card mb-3">
-            <div class="card-header">
-                <div class="card-title" {{ sylius_test_html_attribute('title') }}>
-                    {{ book.title }}
-                </div>
-            </div>
             <div class="card-body" {{ sylius_test_html_attribute('author-name') }}>
                 <strong>{{ 'app.ui.author'|trans }}:</strong>
                 {{ book.authorName }}
@@ -15,5 +10,3 @@
         </div>
     </div>
 </div>
-
-

--- a/tests/Functional/BookTest.php
+++ b/tests/Functional/BookTest.php
@@ -46,10 +46,9 @@ final class BookTest extends WebTestCase
         self::assertResponseIsSuccessful();
 
         // Validate Header
-        self::assertSelectorTextContains('h1.page-title', 'Show Book');
+        self::assertSelectorTextContains('h1.page-title', 'Shinning');
 
         // Validate page body
-        self::assertSelectorTextContains('[data-test-title]', 'Shinning');
         self::assertSelectorTextContains('[data-test-author-name]', 'Stephen King');
     }
 

--- a/tests/Translations/FrenchTranslatedUiTest.php
+++ b/tests/Translations/FrenchTranslatedUiTest.php
@@ -48,8 +48,8 @@ final class FrenchTranslatedUiTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
 
-        // Validate Header
-        self::assertSelectorTextContains('h1.page-title', 'Afficher Livre');
+        // Validate Body
+        self::assertSelectorTextContains('[data-test-author-name] strong', 'Auteur');
     }
 
     public function testBrowsingItems(): void


### PR DESCRIPTION
Fixes #11

```yaml
sylius_twig_hooks:
    hooks:
        'sylius_admin.book.show.content.header.title_block':
            title:
                template: '@SyliusBootstrapAdminUi/shared/crud/common/content/header/title_block/title.html.twig'
                configuration:
                    title: '@=_context.book.getTitle()'
```