### PR TITLE
Fix too many hook prefixes

### DIFF
--- a/src/AdminUi/templates/base.html.twig
+++ b/src/AdminUi/templates/base.html.twig
@@ -1,5 +1,4 @@
 {% set generic_hook = 'sylius_admin.base' %}
-{% set prefixes = prefixes|default([])|merge([generic_hook]) %}
 
 <!DOCTYPE html>
 <html lang="{{ app.request.locale }}">
@@ -8,11 +7,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <title>{% block title %}{% apply striptags %}{% hook '#base_title' with { _prefixes: prefixes } %}{% endapply %}{% endblock %}</title>
+    <title>{% block title %}{% apply striptags %}{% hook generic_hook ~ '#base_title' %}{% endapply %}{% endblock %}</title>
 
     {% block metatags %}{% endblock %}
     {% block stylesheets %}
-        {% hook '#stylesheets' with { _prefixes: prefixes } %}
+        {% hook generic_hook ~ '#stylesheets' %}
     {% endblock %}
 </head>
 <body class="{% block body_class %}{% endblock %}">
@@ -21,7 +20,7 @@
 </div>
 
 {% block javascripts %}
-    {% hook '#javascripts' with { _prefixes: prefixes } %}
+    {% hook generic_hook ~ '#javascripts' %}
 {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
I've merged the hook prefixes with base one to be closer to "shop" bundle, but that was not a good idea.
This is very confusing with "common" one. So I revert that.

Moreover, I implemented that code to be able to change the "base title" (browser page base title) for a specific page, but we can do that with the parent hook key instead, so it was too over-killed.

**Before**
![image](https://github.com/user-attachments/assets/8960eff4-09b8-41c2-805d-82372d8f05c4)

**After**
![Capture d’écran du 2025-01-10 12-59-34](https://github.com/user-attachments/assets/7b48b483-f812-4575-b3b6-595f48ea9e5b)
