### PR TITLE
[BootstrapAdminUi] Add boolean grid field

### DIFF
--- a/src/BootstrapAdminUi/templates/shared/grid/field/boolean.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/grid/field/boolean.html.twig
@@ -1,0 +1,3 @@
+{% import "@SyliusBootstrapAdminUi/shared/helper/field/boolean.html.twig" as boolean %}
+
+{{ boolean.default(data) }}

--- a/src/BootstrapAdminUi/templates/shared/helper/field/boolean.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/helper/field/boolean.html.twig
@@ -1,0 +1,7 @@
+{% macro default(data) %}
+    {% if true == data %}
+        <div class="text-center" {{ sylius_test_html_attribute('status-enabled') }}>{{ ux_icon('tabler:check', {'class': 'icon text-green'}) }}</div>
+    {% else %}
+        <div class="text-center" {{ sylius_test_html_attribute('status-disabled') }}>{{ ux_icon('tabler:x', {'class': 'icon icon-sm text-secondary'}) }}</div>
+    {% endif %}
+{% endmacro %}


### PR DESCRIPTION
This will be documented into #221 

Copied from 
* https://github.com/Sylius/Sylius/blob/2.0/src/Sylius/Bundle/AdminBundle/templates/shared/helper/field/boolean.html.twig
* https://github.com/Sylius/Sylius/blob/2.0/src/Sylius/Bundle/AdminBundle/templates/shared/grid/field/boolean.html.twig