### PR TITLE
[Docs] Switch to embedded syntax for Resource operations

### DIFF
--- a/docs/resource/configure_your_operations.md
+++ b/docs/resource/configure_your_operations.md
@@ -40,8 +40,11 @@ use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Index;
 use Sylius\Resource\Model\ResourceInterface;
 
-#[AsResource]
-#[Index]
+#[AsResource(
+    operations: [
+        new Index(),
+    ],
+)]
 class Book implements ResourceInterface
 {
 }
@@ -78,11 +81,14 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Index;
 
-#[AsResource]
-// You can use either the FQCN of your grid
-#[Index(grid: BookGrid::class)]
-// Or you can use the grid name
-#[Index(grid: 'app_book')]
+#[AsResource(
+    operations: [
+        // You can use either the FQCN of your grid
+        new Index(grid: BookGrid::class),
+        // Or you can use the grid name
+        new Index(grid: 'app_book'),
+    ],
+)]
 class Book implements ResourceInterface
 {
 }
@@ -113,8 +119,11 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Show;
 
-#[AsResource]
-#[Show]
+#[AsResource(
+    operations: [
+        new Show(),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -149,8 +158,11 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Create;
 
-#[AsResource]
-#[Create]
+#[AsResource(
+    operations: [
+        new Create(),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -187,8 +199,11 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Update;
 
-#[AsResource]
-#[Update]
+#[AsResource(
+    operations: [
+        new Update(),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -223,8 +238,11 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Delete;
 
-#[AsResource]
-#[Delete]
+#[AsResource(
+    operations: [
+        new Delete(),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -249,8 +267,11 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\BulkDelete;
 
-#[AsResource]
-#[BulkDelete]
+#[AsResource(
+    operations: [
+        new BulkDelete(),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -277,8 +298,11 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\ApplyStateMachineTransition;
 use Sylius\Resource\Metadata\AsResource;
 
-#[AsResource]
-#[ApplyStateMachineTransition(stateMachineTransition: 'publish')]
+#[AsResource(
+    operations: [
+        new ApplyStateMachineTransition(stateMachineTransition: 'publish'),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -306,9 +330,12 @@ use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Metadata\Update;
 
-#[AsResource]
-#[Create(path: 'register')]
-#[Update(path: '{id}/edition')]
+#[AsResource(
+    operations: [
+        new Create(path: 'register'),
+        new Update(path: '{id}/edition'),
+    ],
+)
 class Customer implements ResourceInterface
 {
 }
@@ -332,8 +359,11 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Create;
 
-#[AsResource]
-#[Create(shortName: 'register')]
+#[AsResource(
+    operations: [
+        new Create(shortName: 'register'),
+    ],
+)
 class Customer implements ResourceInterface
 {
 }
@@ -363,11 +393,15 @@ use Sylius\Resource\Metadata\Index;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Metadata\Update;
 
-#[AsResource(templatesDir: 'book')]
-#[Index]
-#[Create]
-#[Update]
-#[Show]
+#[AsResource(
+    templatesDir: 'book',
+    operations: [
+        new Index(),
+        new Create(),
+        new Update(),
+        new Show(),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -410,13 +444,17 @@ use Sylius\Resource\Metadata\Index;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Metadata\Update;
 
-#[AsResource(routePrefix: 'admin')]
-#[Index]
-#[Create]
-#[Update]
-#[Delete]
-#[BulkDelete]
-#[Show]
+#[AsResource(
+    routePrefix: 'admin',
+    operations: [
+        new Index(),
+        new Create(),
+        new Update(),
+        new Delete(),
+        new BulkDelete(),
+        new Show(),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -449,16 +487,24 @@ use Sylius\Resource\Metadata\Index;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Metadata\Update;
 
-#[AsResource(section: 'admin', routePrefix: 'admin')]
-#[Index]
-#[Create]
-#[Update]
-#[Delete]
-#[BulkDelete]
-
-#[AsResource(section: 'shop')]
-#[Index]
-#[Show]
+#[AsResource(
+    section: 'admin',
+    routePrefix: 'admin',
+    operations: [
+        new Index(),
+        new Create(),
+        new Update(),
+        new Delete(),
+        new BulkDelete(),
+    ],
+)
+#[AsResource(
+    section: 'shop',
+    operations: [
+        new Index(),
+        new Show(),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -491,12 +537,16 @@ use Sylius\Resource\Metadata\Delete;
 use Sylius\Resource\Metadata\Index;
 use Sylius\Resource\Metadata\Update;
 
-#[AsResource(identifier: 'code')]
-#[Index]
-#[Create]
-#[Update]
-#[Delete]
-#[BulkDelete]
+#[AsResource(
+    identifier: 'code',
+    operations: [
+        new Index(),
+        new Create(),
+        new Update(),
+        new Delete(),
+        new BulkDelete(),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -523,8 +573,17 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Create;
 
-#[AsResource(vars: ['header' => 'Library', 'subheader' => 'Managing your library'])]
-#[Create(vars: ['subheader' => 'Adding a book'])]
+#[AsResource(
+    vars: [
+        'header' => 'Library', 
+        'subheader' => 'Managing your library',
+    ],
+    operations: [
+        new Create(vars: [
+            'subheader' => 'Adding a book',
+        ]),
+    ],
+)
 class Book implements ResourceInterface
 {
 }

--- a/docs/resource/configure_your_resource.md
+++ b/docs/resource/configure_your_resource.md
@@ -144,7 +144,12 @@ namespace App\Entity;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Model\ResourceInterface;
 
-#[AsResource(vars: ['header' => 'Library', 'subheader' => 'Managing your library'])]
+#[AsResource(
+    vars: [
+        'header' => 'Library', 
+        'subheader' => 'Managing your library',
+    ],
+)]
 class Book implements ResourceInterface
 {
 }

--- a/docs/resource/processors.md
+++ b/docs/resource/processors.md
@@ -74,8 +74,13 @@ use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Model\ResourceInterface;
 
-#[AsResource]
-#[Create(processor: CreateCustomerProcessor::class)]
+#[AsResource(
+    operations: [
+        new Create(
+            processor: CreateCustomerProcessor::class,
+        ),
+    ],
+)
 final class BoardGameResource implements ResourceInterface
 ```
 {% endcode %}
@@ -120,13 +125,16 @@ use Sylius\Resource\Metadata\Delete;
 use Sylius\Resource\Model\ResourceInterface;
 
 #[AsResource(
-    alias: 'app.board_game',
     section: 'admin',
     formType: BoardGameType::class,
     templatesDir: 'crud',
     routePrefix: '/admin',
-)]
-#[Delete(processor: DeleteBoardGameProcessor::class)]
+    operations: [
+        new Delete(
+            processor: DeleteBoardGameProcessor::class,
+        ),
+    ],
+)
 final class BoardGameResource implements ResourceInterface
 ```
 {% endcode %}
@@ -152,16 +160,17 @@ use Sylius\Resource\Metadata\Update;
 use Sylius\Resource\Model\ResourceInterface;
 
 #[AsResource(
-    alias: 'app.board_game',
     section: 'admin',
     formType: BoardGameType::class,
     templatesDir: 'crud',
     routePrefix: '/admin',
-)]
-#[Update(
-    shortName: 'update_preview',
-    provider: BoardGameItemProvider::class,
-    write: false,    
+    operations: [
+        new Update(
+            shortName: 'update_preview',
+            provider: BoardGameItemProvider::class,
+            write: false,   
+        ),
+    ],
 )]
 final class BoardGameResource implements ResourceInterface
 ```

--- a/docs/resource/providers.md
+++ b/docs/resource/providers.md
@@ -39,8 +39,13 @@ use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Model\ResourceInterface;
 
-#[AsResource]
-#[Show(repositoryMethod: 'findOneByEmail')]
+#[AsResource(
+    operations: [
+        new Show(
+            repositoryMethod: 'findOneByEmail',
+        ),
+    ],
+)
 final class Customer implements ResourceInterface
 {
     // [...]
@@ -71,8 +76,14 @@ use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Model\ResourceInterface;
 
-#[AsResource]
-#[Show(repositoryMethod: 'findOneByEmail', repositoryArguments: ['email' => "request.attributes.get('email')"])]
+#[AsResource(
+    operations: [
+        new Show(
+            repositoryMethod: 'findOneByEmail', 
+            repositoryArguments: ['email' => "request.attributes.get('email')"],
+        ),
+    ],
+)
 final class Customer implements ResourceInterface
 {
     // [...]
@@ -131,8 +142,13 @@ use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Model\ResourceInterface;
 
-#[AsResource]
-#[Show(provider: BoardGameItemProvider::class)]
+#[AsResource(
+    operations: [
+        new Show(
+            provider: BoardGameItemProvider::class, 
+        ),
+    ],
+)
 final class BoardGameResource implements ResourceInterface
 {
     // [...]
@@ -158,11 +174,14 @@ use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Delete;
 use Sylius\Resource\Model\ResourceInterface;
 
-#[AsResource]
-#[Delete(
-    processor: DeleteBoardGameProcessor::class,
-    read: false,
- )]
+#[AsResource(
+    operations: [
+        new Delete(
+            processor: DeleteBoardGameProcessor::class,
+            read: false,
+        ),
+    ],
+)
 final class BoardGameResource implements ResourceInterface
 {
     // [...]

--- a/docs/resource/redirect.md
+++ b/docs/resource/redirect.md
@@ -36,9 +36,16 @@ use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Metadata\Update;
 use Sylius\Resource\Model\ResourceInterface;
 
-#[AsResource]
-#[Create(redirectToRoute: 'app_book_update')]
-#[Update(redirectToRoute: 'app_book_update')]
+#[AsResource(
+    operations: [
+        new Create(
+            redirectToRoute: 'app_book_update',
+        ),
+        new Update(
+            redirectToRoute: 'app_book_update',
+        ),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -72,14 +79,17 @@ use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Model\ResourceInterface;
 
-#[AsResource]
-#[Create(
-    redirectToRoute: 'app_author_show', 
-    # You can use either the generic resource variable
-    redirectArguments: ['id' => 'resource.getAuthor().getId()']
-    # Or you can use the resource name
-    redirectArguments: ['id' => 'book.getAuthor().getId()']
-)]
+#[AsResource(
+    operations: [
+        new Create(
+            redirectToRoute: 'app_author_show', 
+            # You can use either the generic resource variable
+            redirectArguments: ['id' => 'resource.getAuthor().getId()']
+            # Or you can use the resource name
+            redirectArguments: ['id' => 'book.getAuthor().getId()']
+        ),
+    ],
+)
 class Book implements ResourceInterface
 {
 }

--- a/docs/resource/resource_factories.md
+++ b/docs/resource/resource_factories.md
@@ -130,11 +130,14 @@ use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Model\ResourceInterface;
 
-#[AsResource]
-#[Create(
-    path: 'authors/{authorId}/books',
-    factoryMethod: 'createWithCreator',
-)]
+#[AsResource(
+    operations: [
+        new Create(
+            path: 'authors/{authorId}/books',
+            factoryMethod: 'createWithCreator',
+        ),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -202,12 +205,15 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Create;
 
-#[AsResource]
-#[Create(
-    path: 'authors/{authorId}/books',
-    factoryMethod: 'createForAuthor',
-    factoryArguments: ['authorId' => "request.attributes.get('authorId')"],
-)]
+#[AsResource(
+    operations: [
+        new Create(
+            path: 'authors/{authorId}/books',
+            factoryMethod: 'createForAuthor',
+            factoryArguments: ['authorId' => "request.attributes.get('authorId')"],
+        ),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -230,14 +236,17 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Create;
 
-#[AsResource]
-#[Create(
-    path: 'authors/{authorId}/books',
-    # Here we declared the factory to use with its fully classified class name
-    factory: BookFactory::class,
-    factoryMethod: 'createForAuthor', 
-    factoryArguments: ['authorId' => "request.attributes.get('authorId')"],
-)]
+#[AsResource(
+    operations: [
+        new Create(
+            path: 'authors/{authorId}/books',
+            # Here we declared the factory to use with its fully classified class name
+            factory: BookFactory::class,
+            factoryMethod: 'createForAuthor', 
+            factoryArguments: ['authorId' => "request.attributes.get('authorId')"],
+        ),
+    ],
+)
 class Book implements ResourceInterface
 {
 }
@@ -278,10 +287,13 @@ use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Model\ResourceInterface
 
-#[AsResource]
-#[Create(
-    factory: [BookFactory::class, 'create'], 
-)]
+#[AsResource(
+    operations: [
+        new Create(
+            factory: [BookFactory::class, 'create'], 
+        ),
+    ],
+)
 class Book implements ResourceInterface
 {
 }

--- a/docs/resource/responders.md
+++ b/docs/resource/responders.md
@@ -71,11 +71,14 @@ use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Model\ResourceInterface;
 
-#[AsResource]
-#[Show(
-    template: 'subscription/show.html.twig',
-    twigContextFactory: ShowSubscriptionContextFactory::class,
-)]
+#[AsResource(
+    operations: [
+        new Show(
+            template: 'subscription/show.html.twig',
+            twigContextFactory: ShowSubscriptionContextFactory::class,      
+        ),
+    ],
+)
 class Subscription implements ResourceInterface
 {
 }

--- a/docs/resource/validation.md
+++ b/docs/resource/validation.md
@@ -22,8 +22,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[AsResource(
     formType: BookType::class, 
+    operations: [
+        new Create(),
+    ],
 )
-#[Create]
 class Book implements ResourceInterface
 {
     // ...
@@ -47,8 +49,11 @@ use Sylius\Resource\Model\ResourceInterface;
 use Sylius\Resource\Metadata\AsResource;
 use Symfony\Component\Validator\Constraints as Assert;
 
-#[AsResource()
-#[Post]
+#[AsResource(
+    operations: [
+        new Post(),
+    ],
+)
 class Book implements ResourceInterface
 {
     // ...
@@ -81,12 +86,14 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[AsResource(
     formType: BoardGameType::class, 
+    operations: [
+        new Update(
+            provider: BoardGameItemProvider::class, 
+            processor: PublishBoardGameProcessor::class,
+            validate: false, // disable resource validation        
+        ),
+    ],
 )
-#[Update(
-    provider: BoardGameItemProvider::class, 
-    processor: PublishBoardGameProcessor::class,
-    validate: false, // disable resource validation
- )]
 class BoardGameResource implements ResourceInterface
 {
 }


### PR DESCRIPTION
On the beginning of that implementation, I preferred the previous syntax but after two years of new operations usage, I prefer that embedded syntax and I think the other one should be removed at some point to simplify the code maintenance.

We already use that syntax on the Cookbook.