### PR TITLE
[Fix] align bulk action buttons when more than one

### DIFF
--- a/src/BootstrapAdminUi/templates/shared/crud/index/content/grid/data_table.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/crud/index/content/grid/data_table.html.twig
@@ -10,7 +10,7 @@
         <div class="card-body border-bottom py-3">
             <div class="d-flex">
                 {% if data|length > 0 and definition.actionGroups.bulk is defined and definition.getEnabledActions('bulk')|length > 0 %}
-                    <div class="sylius-grid-nav__bulk">
+                    <div class="sylius-grid-nav__bulk grid">
                         {% for action in definition.getEnabledActions('bulk') %}
                             {{ sylius_grid_render_bulk_action(resources, action, null) }}
                         {% endfor %}


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/2238b896-a45f-47f9-b597-cce4300df123)

After
![image](https://github.com/user-attachments/assets/ab8d3d74-0e15-4338-890a-60261b78e403)
