### PR TITLE
[Twig Hooks] Load debug services only in dev environment

### DIFF
--- a/src/TwigHooks/config/services/debug/twig_events.php
+++ b/src/TwigHooks/config/services/debug/twig_events.php
@@ -22,6 +22,11 @@ use Sylius\TwigHooks\Profiler\Profile;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 return static function (ContainerBuilder $container, ContainerConfigurator $configurator): void {
+    $env = $container->getParameter('kernel.environment');
+    if ($env !== 'dev') {
+        return;
+    }
+
     $services = $configurator->services();
 
     $services->set('sylius_twig_hooks.renderer.hook.debug_comment', HookDebugCommentRenderer::class)


### PR DESCRIPTION
Fixes problem in Behat tests: https://github.com/Sylius/WishlistPlugin/actions/runs/15676634929/job/44158368819?pr=12#step:30:22

due to:
```
An exception has been thrown during the rendering of a template ("Warning: Undefined variable $rendered in /Users/gsadee/Sites/Sylius/WishlistPlugin/vendor/sylius/twig-hooks/src/Hookable/Renderer/Debug/HookableProfilerRenderer.php line 42") in @SyliusShop/shared/layout/base.html.twig at line 11.
```