### PR TITLE
[Docs] Add "Configure the routes' name" section to resource/configure_your_operations.md

### DIFF
--- a/docs/resource/configure_your_operations.md
+++ b/docs/resource/configure_your_operations.md
@@ -447,7 +447,7 @@ use Sylius\Resource\Metadata\Update;
 #[AsResource(
     routePrefix: 'admin',
     operations: [
-        new Index(routePrefix: ''),
+        new Index(routePrefix: ''),  // you can also customize the route prefix at the operation level too for extra flexibility
         new Create(),
         new Update(),
         new Delete(),


### PR DESCRIPTION
Since the `routeName` for operation attributes was not documented, I've added a simple example, similar to the "Configure the routes' prefix" section, showing how to use this argument. Additionally, I've included an example of `routePrefix` that can be specified at the `AsResource` level and can be overridden for each operation separately.