### PR TITLE
Fix data table template when no grid is attached to the index operation

### DIFF
--- a/app/Entity/Book.php
+++ b/app/Entity/Book.php
@@ -36,6 +36,10 @@ use Symfony\Component\Validator\Constraints\NotBlank;
         new Create(),
         new Update(),
         new Index(grid: BookGrid::class),
+        new Index(
+            template: '@SyliusAdminUi/crud/index.html.twig',
+            shortName: 'withoutGrid',
+        ),
         new Delete(),
         new BulkDelete(),
         new Show(),

--- a/src/BootstrapAdminUi/templates/shared/crud/index/content/grid/data_table.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/crud/index/content/grid/data_table.html.twig
@@ -2,8 +2,8 @@
 {% import '@SyliusBootstrapAdminUi/shared/helper/pagination.html.twig' as pagination %}
 
 {% set resources = hookable_metadata.context.resources %}
-{% set data = resources.data %}
-{% set definition = resources.definition %}
+{% set data = resources.data|default([]) %}
+{% set definition = resources.definition|default(null) %}
 
 {% if data|length > 0 %}
     <div class="card">

--- a/src/BootstrapAdminUi/templates/shared/crud/index/content/grid/filters.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/crud/index/content/grid/filters.html.twig
@@ -6,7 +6,7 @@
 {% set path = path(app.request.attributes.get('_route'), app.request.attributes.all('_route_params')) %}
 {% set are_criteria_set = app.request.query.has('criteria') %}
 
-{% if resources.definition.enabledFilters is not empty %}
+{% if resources.definition.enabledFilters|default([]) is not empty %}
     <div class="position-relative z-1 bg-white mb-5">
         {% set content %}
             <div class="mb-3">

--- a/src/BootstrapAdminUi/templates/shared/crud/index/content/grid/no_results.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/crud/index/content/grid/no_results.html.twig
@@ -1,6 +1,6 @@
 {% set resources = hookable_metadata.context.resources %}
 
-{% if resources.data|length == 0 %}
+{% if resources.data is defined and resources.data|length == 0 %}
     <div class="card">
         <div class="empty">
             {% hook 'no_results' %}

--- a/tests/Functional/BookTest.php
+++ b/tests/Functional/BookTest.php
@@ -98,6 +98,28 @@ final class BookTest extends WebTestCase
         self::assertSelectorExists('tr.item:last-child [data-bs-title=Delete]');
     }
 
+    public function testBrowsingBooksWithoutGrid(): void
+    {
+        BookFactory::new()
+            ->withTitle('The Shining')
+            ->withAuthorName('Stephen King')
+            ->create()
+        ;
+
+        BookFactory::new()
+            ->withTitle('Carrie')
+            ->withAuthorName('Stephen King')
+            ->create()
+        ;
+
+        $this->client->request('GET', '/admin/books/withoutGrid');
+
+        self::assertResponseIsSuccessful();
+
+        // Validate Header
+        self::assertSelectorTextContains('[data-test-page-title]', 'Books');
+    }
+
     public function testSortingBooks(): void
     {
         BookFactory::new()


### PR DESCRIPTION
Before
<img width="1683" height="751" alt="image" src="https://github.com/user-attachments/assets/45e8cb55-435f-47c0-8fb8-377c0f2cc016" />

After
<img width="1683" height="751" alt="image" src="https://github.com/user-attachments/assets/fe8b6daf-7d13-4234-86c0-3ed93fd6597b" />
