### PR TITLE
[AdminUi] Add a Twig global variable for the context

### DIFF
--- a/importmap.php
+++ b/importmap.php
@@ -45,4 +45,12 @@ return [
     '@symfony/ux-live-component' => [
         'path' => './vendor/symfony/ux-live-component/assets/dist/live_controller.js',
     ],
+    'tom-select/dist/css/tom-select.bootstrap4.css' => [
+        'version' => '2.4.3',
+        'type' => 'css',
+    ],
+    'tom-select/dist/css/tom-select.bootstrap5.css' => [
+        'version' => '2.4.3',
+        'type' => 'css',
+    ],
 ];

--- a/src/AdminUi/config/services.php
+++ b/src/AdminUi/config/services.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Sylius\AdminUi\Context\Context;
+use Sylius\AdminUi\Context\RoutingContext;
 use Sylius\AdminUi\Knp\Menu\MenuBuilder;
 use Sylius\AdminUi\Knp\Menu\MenuBuilderInterface;
 use Sylius\AdminUi\TwigHooks\Hookable\Metadata\RoutingHookableMetadataFactory;
@@ -33,6 +35,18 @@ return function (ContainerConfigurator $configurator): void {
         ->args([
             service('.inner'),
             param('sylius_admin_ui.routing'),
+        ])
+    ;
+
+    $services->set('sylius_admin_ui.routing_context', RoutingContext::class)
+        ->args([
+            param('sylius_admin_ui.routing'),
+        ])
+    ;
+
+    $services->set('sylius_admin_ui.context', Context::class)
+        ->args([
+            service('sylius_admin_ui.routing_context'),
         ])
     ;
 };

--- a/src/AdminUi/config/services/twig/extension.php
+++ b/src/AdminUi/config/services/twig/extension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Sylius\AdminUi\Twig\Extension\ContextExtension;
 use Sylius\AdminUi\Twig\Extension\RedirectPathExtension;
 
 return function (ContainerConfigurator $configurator): void {
@@ -22,6 +23,13 @@ return function (ContainerConfigurator $configurator): void {
         ->args([
             service('router'),
             service('sylius.grid.filter_storage')->nullOnInvalid(),
+        ])
+        ->tag(name: 'twig.extension')
+    ;
+
+    $services->set('sylius_admin_ui.twig.extension.context', ContextExtension::class)
+        ->args([
+            service('sylius_admin_ui.context'),
         ])
         ->tag(name: 'twig.extension')
     ;

--- a/src/AdminUi/src/Context/Context.php
+++ b/src/AdminUi/src/Context/Context.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\AdminUi\Context;
+
+final class Context
+{
+    public function __construct(
+        private readonly RoutingContext $routing,
+    ) {
+    }
+
+    public function getRouting(): RoutingContext
+    {
+        return $this->routing;
+    }
+}

--- a/src/AdminUi/src/Context/RoutingContext.php
+++ b/src/AdminUi/src/Context/RoutingContext.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\AdminUi\Context;
+
+final class RoutingContext
+{
+    public function __construct(
+        private readonly array $routing,
+    ) {
+    }
+
+    public function getDashboardPath(): string
+    {
+        return $this->routing['dashboard_path'] ?? '/admin';
+    }
+}

--- a/src/AdminUi/src/Twig/Extension/ContextExtension.php
+++ b/src/AdminUi/src/Twig/Extension/ContextExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\AdminUi\Twig\Extension;
+
+use Sylius\AdminUi\Context\Context;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+
+final class ContextExtension extends AbstractExtension implements GlobalsInterface
+{
+    public function __construct(
+        private readonly Context $context,
+    ) {
+    }
+
+    public function getGlobals(): array
+    {
+        return [
+            'sylius_admin_ui_context' => $this->context,
+        ];
+    }
+}

--- a/src/BootstrapAdminUi/templates/shared/crud/common/sidebar/logo.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/crud/common/sidebar/logo.html.twig
@@ -1,4 +1,4 @@
-{% set dashboard_path = hookable_metadata.context.routing.dashboard_path|default('/admin') %}
+{% set dashboard_path = sylius_admin_ui_context.routing.dashboardPath %}
 
 <h1 class="navbar-brand">
     <a href="{{ dashboard_path }}">

--- a/src/BootstrapAdminUi/templates/shared/crud/create/content/header/breadcrumbs.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/crud/create/content/header/breadcrumbs.html.twig
@@ -14,7 +14,7 @@
 )
 %}
 
-{% set dashboard_path = hookable_metadata.context.routing.dashboard_path|default('/admin') %}
+{% set dashboard_path = sylius_admin_ui_context.routing.dashboardPath %}
 
 {{ breadcrumbs([
     { name: 'sylius.ui.dashboard', url: dashboard_path, active: false },

--- a/src/BootstrapAdminUi/templates/shared/crud/index/content/header/breadcrumbs.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/crud/index/content/header/breadcrumbs.html.twig
@@ -9,7 +9,7 @@
     {% set title = hookable_metadata.configuration.title %}
 {% endif %}
 
-{% set dashboard_path = hookable_metadata.context.routing.dashboard_path|default('/admin') %}
+{% set dashboard_path = sylius_admin_ui_context.routing.dashboardPath %}
 
 {{ breadcrumbs([
     { 'name': 'sylius.ui.dashboard', 'url': dashboard_path, 'active': false },

--- a/src/BootstrapAdminUi/templates/shared/crud/show/content/header/breadcrumbs.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/crud/show/content/header/breadcrumbs.html.twig
@@ -28,7 +28,7 @@
     {% set resource_show = { name: resource_show_name, active: true} %}
 {% endif %}
 
-{% set dashboard_path = hookable_metadata.context.routing.dashboard_path|default('/admin') %}
+{% set dashboard_path = sylius_admin_ui_context.routing.dashboardPath %}
 
 {{ breadcrumbs([
     { name: 'sylius.ui.dashboard', url: dashboard_path, active: false },

--- a/src/BootstrapAdminUi/templates/shared/crud/update/content/header/breadcrumbs.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/crud/update/content/header/breadcrumbs.html.twig
@@ -24,7 +24,7 @@
     {% set resource_edit = { name: resource_edit_name, active: true} %}
 {% endif %}
 
-{% set dashboard_path = hookable_metadata.context.routing.dashboard_path|default('/admin') %}
+{% set dashboard_path = sylius_admin_ui_context.routing.dashboardPath %}
 
 {{ breadcrumbs([
     { name: 'sylius.ui.dashboard', url: dashboard_path, active: false },

--- a/symfony.lock
+++ b/symfony.lock
@@ -11,6 +11,15 @@
             "ref": "64d8583af5ea57b7afa4aba4b159907f3a148b05"
         }
     },
+    "doctrine/deprecations": {
+        "version": "1.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "87424683adc81d7dc305eefec1fced883084aab9"
+        }
+    },
     "doctrine/doctrine-bundle": {
         "version": "2.12",
         "recipe": {


### PR DESCRIPTION
Add a better DX for the admin ui context.
```diff
- {% set dashboard_path = hookable_metadata.context.routing.dashboard_path|default('/admin') %}
+ {% set dashboard_path = sylius_admin_ui_context.routing.dashboardPath %}
```

Then, we have an autocompletion on our IDE.
<img width="900" height="227" alt="image" src="https://github.com/user-attachments/assets/fc1177cc-ae6d-4c9d-a2e4-b5ce65d13da8" />