### PR TITLE
fix: [Docs][Hookables] display Twig templates examples

### DIFF
--- a/docs/twig-hooks/passing-data-to-your-hookables.md
+++ b/docs/twig-hooks/passing-data-to-your-hookables.md
@@ -1,11 +1,12 @@
 # Passing data to your hookables
 
-One of the most powerful aspects of hooks & hookables is an ability to pass their data down to the children. We can have two sources of the context data:
+One of the most powerful aspects of hooks & hookables is the ability to pass data down to their children.
+We can have two sources for context data:
 
 * Hook-level defined data
 * Hookable-level defined data
 
-The context data from these two sources are merged and passed with the metadata to the hookable template or component, so we can use them.
+Context data from these two sources is merged and passed to the hookable template or component together with the metadata, so we can use them.
 
 <div data-full-width="false">
 
@@ -15,55 +16,71 @@ The context data from these two sources are merged and passed with the metadata 
 
 ### Example
 
-{% code title="index.html.twig" lineNumbers="true" fullWidth="false" %}
-```twig
-{#
- # we assume there is a `form` variable holding a `FormView` instance passed
- # from the controller
- #}
+Let's assume we are rendering a form in our `index.html.twig` template via a `form` variable containing a `FormView` instance.
+Here, we define an `index.form` hook, and we can pass it the `form`'s context data thanks to the `with` keyword.
+This means that we can technically pass down multiple pieces of data to hookables that will hook into `index.form`.
 
-<div class="container">
-    {{ form_start(form) }}
+{% code title="index.html.twig" lineNumbers="true" %}
+```twig
+    <div class="container">
+    {% raw %}
+        {{ form_start(form) }}  
         {{ form_errors(form) }}
         {{ form_widget(form._token) }}
-    
-        {% raw %}
-{% hook 'index.form' with { form } %}
-{% endraw %}
-    {{ form_end(form, {render_rest: false}) }}
-</div>
+        
+        {% hook 'index.form' with { form } %}
+        {{ form_end(form, {render_rest: false}) }}
+    {% endraw %}
+    </div>
 ```
 {% endcode %}
-
-So, as we see at `line 11` we define the `index.form` hook. But also, we pass the `form` with using the `with` keyword. Thanks to it, we are able to pass multiple data to hookables that will hook into the `index.form` hook.
 
 {% hint style="info" %}
-`with { form }` is a short-hand for `with { form: form }`, so the key for our `FormView` in the context data bag will be `form.`
+`with { form }` is a short-hand for `with { form: form }`, so the key for our `FormView` in the context data bag will be `form`.
 {% endhint %}
 
-Now let's create a Twig template rendering some field from our form, and let's make it a hookable.
+Now let's create a Twig template that renders a field from our form and make it hookable. We have 3 possible options : 
 
+{% tabs %}
+{% tab title="hookable_metadata.context tag" %}
 {% code title="index/some_field.html.twig" lineNumbers="true" %}
 ```twig
+{% raw %}
 <div class="field">
      {{ form_row(hookable_metadata.context.form.some_field) }}
-     
-     {# we can also write it like #}
-     
-     {% raw %}
-{% set context = hookable_metadata.context %}
-     
-     {{ form_row(context.form.some_field) }}
-     
-     {# or #}
-     
-     {% set context = get_hookable_context() %}
+</div>
 {% endraw %}
+```
+{% endcode %}
+{% endtab %}
+
+{% tab title="local context variable" %}
+{% code title="index/some_field.html.twig" lineNumbers="true" %}
+```twig
+{% raw %}
+<div class="field">
+    {% set context = hookable_metadata.context %}
+     {{ form_row(context.form.some_field) }}
+</div>
+{% endraw %}
+```
+{% endcode %}
+{% endtab %}
+
+{% tab title="get_hookable_context()" %}
+{% code title="index/some_field.html.twig" lineNumbers="true" %}
+```twig
+{% raw %}
+<div class="field">
+     {% set context = get_hookable_context() %}
      
      {{ form_row(context.form.some_field) }}
 </div>
+{% endraw %}
 ```
 {% endcode %}
+{% endtab %}
+{% endtabs %}
 
 {% hint style="info" %}
 You can access the context data in multiple ways, so you can pick the one you like the most. Available options are:
@@ -73,5 +90,7 @@ You can access the context data in multiple ways, so you can pick the one you li
 {% endhint %}
 
 {% hint style="info" %}
-Sometimes you might want to override some data that are defined at the hook-level. It is possible by defining the same context data key on the hookable level. If the same context data key is defined at both hook-level and hookable-level the hookable-level one is used.
+Sometimes you might want to override data that is defined at the hook level. You can do this by defining the same
+context data key at the hookable level. If the same context data key is defined at both hook level and hookable level
+the hookable level one is used.
 {% endhint %}


### PR DESCRIPTION
EDIT : I opened a Git Book PR instead as this was too buggy !!!

- Fixes the Twig templates not being displayed properly in gitbook because of misplaced {% raw %} tags
- Fixes typos / grammar : reword some sentences for clarity
- Use tabs instead of "or" comments inside twig templates for visual clarity too