### PR TITLE
[Docs][BootstrapAdminUi] Copy usage with Sylius resource package

### DIFF
--- a/docs/bootstrap-admin-ui/getting-started.md
+++ b/docs/bootstrap-admin-ui/getting-started.md
@@ -21,7 +21,7 @@ CRUD templates are split into configurable blocks.
 
 You can add new blocks, disable existing ones, or reorder them using the [TwigHooks package](../twig-hooks/getting-started.md).
 
-*Usage with Sylius Resource package*
+### Usage with the Sylius Resource package
 
 {% code title="src/Entity/Speaker.php" lineNumbers="true" %}
 ```php


### PR DESCRIPTION
We already have this example code here
https://github.com/Sylius/Stack/blob/main/docs/admin-ui/getting-started.md#crud-templates

But to ensure that users find the information, we can also adding it here.
https://stack.sylius.com/~/revisions/NuG6wpwKbLILmM1LB1yz/bootstrap-admin-ui/getting-started#configuring-the-crud-templates