### PR TITLE
[Docs] Collapse menu items

### DIFF
--- a/docs/cookbook/admin_panel/menu.md
+++ b/docs/cookbook/admin_panel/menu.md
@@ -95,9 +95,10 @@ final readonly class MenuBuilder implements MenuBuilderInterface
 It's possible to expand your parent menu category on page load by default. For that, you have to set the `setExtra` attribute like this:
 
 ```php
-$newSubmenu = $menu
-    ->addChild('new')
-    ->setLabel('Custom Admin Menu')
+$library = $menu
+    ->addChild('library')
+    ->setLabel('app.ui.library')
+    ->setLabelAttribute('icon', 'tabler:books')
     ->setExtra('always_open', true);
 ```
 


### PR DESCRIPTION
I've just copied the recent change on Sylius documentation side, cause it's not documented here too.

On Sylius documentation
<img width="840" height="275" alt="image" src="https://github.com/user-attachments/assets/9fef7106-96f5-44ef-851d-b75d4e2a6a39" />

On Sylius stack documentation preview
<img width="840" height="275" alt="image" src="https://github.com/user-attachments/assets/539bc3c8-c8eb-4ba4-bc2e-5bcfa50f1ad2" />
