### PR TITLE
[AdminUi] Add a full layout

### DIFF
--- a/config/reference.php
+++ b/config/reference.php
@@ -767,6 +767,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type LiveComponentConfig = array{
  *     secret?: scalar|Param|null, // The secret used to compute fingerprints and checksums // Default: "%kernel.secret%"
+ *     fetch_credentials?: "same-origin"|"include"|"omit"|Param, // The default fetch credentials mode for all Live Components ('same-origin', 'include', 'omit') // Default: "same-origin"
  * }
  * @psalm-type StimulusConfig = array{
  *     controller_paths?: list<scalar|Param|null>,
@@ -1474,6 +1475,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         path?: scalar|Param|null, // The local icon set directory path. (cannot be used with 'alias')
  *         alias?: scalar|Param|null, // The remote icon set identifier. (cannot be used with 'path')
  *         icon_attributes?: array<string, scalar|Param|null>,
+ *         suffixes?: array<string, array{ // The suffix name (e.g. "solid", "20-solid") // Default: []
+ *             icon_attributes?: array<string, scalar|Param|null>,
+ *         }>,
  *     }>,
  *     aliases?: array<string, string|Param>,
  *     iconify?: bool|array{ // Configuration for the remote icon service.

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -3,3 +3,15 @@ index:
     controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
     defaults:
         template: base.html.twig
+
+admin_simple_page:
+    path: /admin/page/simple
+    controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+    defaults:
+        template: 'page/simple.html.twig'
+
+admin_page_with_hooks:
+    path: /admin/page/with-hooks
+    controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+    defaults:
+        template: 'page/with_hooks.html.twig'

--- a/config/sylius/twig_hooks/page.php
+++ b/config/sylius/twig_hooks/page.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->extension('sylius_twig_hooks', [
+        'hooks' => [
+            'app.page#navbar' => [
+                'content' => [
+                    'enabled' => false,
+                ],
+            ],
+            'app.page#main' => [
+                'body' => [
+                    'template' => 'page/with_hooks/body.html.twig',
+                ],
+            ],
+        ],
+    ]);
+};

--- a/src/AdminUi/templates/layout/full_layout.html.twig
+++ b/src/AdminUi/templates/layout/full_layout.html.twig
@@ -1,0 +1,23 @@
+{% extends '@SyliusAdminUi/base.html.twig' %}
+
+{% set prefixes = prefixes|default({})|merge([
+    'sylius_admin.common.full_layout',
+]) %}
+
+{% block body %}
+    {% block sidebar %}
+        {% hook '#sidebar' with {_prefixes: prefixes} %}
+    {% endblock %}
+
+    {% block navbar %}
+        {% hook '#navbar' with {_prefixes: prefixes} %}
+    {% endblock %}
+
+    {% block main %}
+        {% hook '#main' with {_prefixes: prefixes} %}
+    {% endblock %}
+
+    {% block footer %}
+        {% hook '#footer' with {_prefixes: prefixes} %}
+    {% endblock %}
+{% endblock %}

--- a/src/BootstrapAdminUi/config/app/twig_hooks/layout/full_layout.php
+++ b/src/BootstrapAdminUi/config/app/twig_hooks/layout/full_layout.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->extension('sylius_twig_hooks', [
+        'hooks' => [
+            'sylius_admin.common.full_layout#sidebar' => [
+                'content' => [
+                    'template' => '@SyliusBootstrapAdminUi/shared/crud/common/sidebar.html.twig',
+                ],
+            ],
+            'sylius_admin.common.full_layout#navbar' => [
+                'content' => [
+                    'template' => '@SyliusBootstrapAdminUi/shared/crud/common/navbar.html.twig',
+                ],
+            ],
+            'sylius_admin.common.full_layout#footer' => [
+                'content' => [
+                    'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/footer.html.twig',
+                ],
+            ],
+        ],
+    ]);
+};

--- a/templates/page/simple.html.twig
+++ b/templates/page/simple.html.twig
@@ -1,0 +1,15 @@
+{% extends '@SyliusAdminUi/layout/full_layout.html.twig' %}
+
+{% block main %}
+    <div class="page-wrapper">
+        <div class="page-body">
+            <div class="container-xl">
+                <div class="row">
+                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ac felis nec sapien interdum luctus. Integer non sapien in urna faucibus pharetra. Vivamus vitae justo at arcu gravida aliquam. Sed congue eros id dolor faucibus, in iaculis arcu lacinia.</p>
+                    <h3>Section</h3>
+                    <p>Phasellus euismod, justo in facilisis lacinia, massa arcu convallis libero, sed consequat dolor nisl sit amet libero. Aenean euismod sem vel turpis ultrices, vitae laoreet leo sodales.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/page/with_hooks.html.twig
+++ b/templates/page/with_hooks.html.twig
@@ -1,0 +1,3 @@
+{% extends '@SyliusAdminUi/layout/full_layout.html.twig' %}
+
+{% set prefixes = ['app.page'] %}

--- a/templates/page/with_hooks/body.html.twig
+++ b/templates/page/with_hooks/body.html.twig
@@ -1,0 +1,11 @@
+<div class="page-wrapper">
+    <div class="page-body">
+        <div class="container-xl">
+            <div class="row">
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ac felis nec sapien interdum luctus. Integer non sapien in urna faucibus pharetra. Vivamus vitae justo at arcu gravida aliquam. Sed congue eros id dolor faucibus, in iaculis arcu lacinia.</p>
+                <h3>Section</h3>
+                <p>Phasellus euismod, justo in facilisis lacinia, massa arcu convallis libero, sed consequat dolor nisl sit amet libero. Aenean euismod sem vel turpis ultrices, vitae laoreet leo sodales.</p>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
### Extending a full layout
```twig
{% extends '@SyliusAdminUi/layout/full_layout.html.twig' %}

{% block main %}
    <div class="page-wrapper">
        <div class="page-body">
            <div class="container-xl">
                <div class="row">
                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ac felis nec sapien interdum luctus. Integer non sapien in urna faucibus pharetra. Vivamus vitae justo at arcu gravida aliquam. Sed congue eros id dolor faucibus, in iaculis arcu lacinia.</p>
                    <h3>Section</h3>
                    <p>Phasellus euismod, justo in facilisis lacinia, massa arcu convallis libero, sed consequat dolor nisl sit amet libero. Aenean euismod sem vel turpis ultrices, vitae laoreet leo sodales.</p>
                </div>
            </div>
        </div>
    </div>
{% endblock %}
```

<img width="1682" height="1074" alt="image" src="https://github.com/user-attachments/assets/a175d7af-09ad-42d0-a8db-d4469c594762" />

### and even using custom hooks
```twig
{% extends '@SyliusAdminUi/layout/full.html.twig' %}

{% set prefixes = ['app.cms_page'] %}
```

```php
return static function (ContainerConfigurator $container): void {
    $container->extension('sylius_twig_hooks', [
        'hooks' => [
            'app.cms_page#navbar' => [
                'content' => [
                    'enabled' => false,
                ],
            ],
            'app.cms_page#content' => [
                'body' => [
                    'template' => 'cms/page/with_hooks/body.html.twig',
                ],
            ],
        ],
    ]);
};

```

<img width="1682" height="1074" alt="image" src="https://github.com/user-attachments/assets/fec3a84d-a549-4730-bff2-ba58cbf20280" />

