### PR TITLE
TASK: [DOCS] adjust firewall config docs

### DIFF
--- a/docs/cookbook/admin_panel/security.md
+++ b/docs/cookbook/admin_panel/security.md
@@ -77,7 +77,7 @@ security:
 {% endcode %}
 
 {% hint style="warning" %}  
-It's important to move the main block under the admin configuration. Otherwise the admin login functionality won't work properly:
+It's important to move the main block under the admin configuration. Otherwise the admin login functionality won't work properly.
 {% endhint %}
 
 {% hint style="info" %}


### PR DESCRIPTION
I had a debugging session with @loic425

And we found out that when the `main` block that comes with symfony is above the `admin` firewall config part, the login too the admin does not work and if you call the `admin` route in your browser it returns a exception.

Exception when logging in too the admin:

```
Unable to find the controller for path "/admin/login_check". The route is wrongly configured.
```

Exception when call `domain.com/admin`:
```
Full authentication is required to access this resource.
```