### PR TITLE
fix(tool): [link] add missing `Path` class

### DIFF
--- a/link
+++ b/link
@@ -19,6 +19,7 @@ require __DIR__.'/vendor/symfony/filesystem/Exception/ExceptionInterface.php';
 require __DIR__.'/vendor/symfony/filesystem/Exception/IOExceptionInterface.php';
 require __DIR__.'/vendor/symfony/filesystem/Exception/IOException.php';
 require __DIR__.'/vendor/symfony/filesystem/Filesystem.php';
+require __DIR__.'/vendor/symfony/filesystem/Path.php';
 
 use Symfony\Component\Filesystem\Filesystem;
 


### PR DESCRIPTION
refers symfony/symfony#62425
btw i think using `require __DIR__.'/vendor/autoload.php';` instead of all manual requires like in `symfony/ux` repo would be more relevant but maybe less efficient tho..
