### PR TITLE
Add a modal id prop on the delete modal component

### DIFF
--- a/src/BootstrapAdminUi/templates/shared/components/delete_modal.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/components/delete_modal.html.twig
@@ -1,8 +1,11 @@
 {% extends '@SyliusBootstrapAdminUi/shared/components/confirmation_modal.html.twig' %}
 {% import '@SyliusBootstrapAdminUi/shared/helper/button.html.twig' as button %}
 
-{% props id = null, path = null, label = 'sylius.ui.delete', icon = 'tabler:trash-x', disabled = false, form_attr = null, type = 'delete' %}
-{% set modal_id = 'delete-modal-' ~ id %}
+{% props id = null, path = null, label = 'sylius.ui.delete', icon = 'tabler:trash-x', disabled = false, form_attr = null, type = 'delete', modal_id = null %}
+
+{% if modal_id is null %}
+    {% set modal_id = 'delete-modal-' ~ id %}
+{% endif %}
 
 {% block trigger %}
     <div data-bs-toggle="tooltip" data-bs-title="{{ label|trans }}">


### PR DESCRIPTION
Needed for my WIP work at Jolicode.

```twig
{{ component('sylius_bootstrap_admin_ui:delete_modal', {
    id: directory, 
    modal_id: 'delete-directory-modal-' ~ loop.index , 
    path: path('joli_media_sylius_admin_delete_directory', {'key': directory})
}) }}
```

Here my path is a directory label, so it could contains any characters.