### PR TITLE
fix(ci): PHPStan error on debug twig hooks command

### DIFF
--- a/src/TwigHooks/src/Console/Command/DebugTwigHooksCommand.php
+++ b/src/TwigHooks/src/Console/Command/DebugTwigHooksCommand.php
@@ -89,7 +89,7 @@ EOF
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
     {
         if ($input->mustSuggestArgumentValuesFor('name')) {
-            $suggestions->suggestValues($this->hookablesRegistry->getHookNames());
+            $suggestions->suggestValues(array_values($this->hookablesRegistry->getHookNames()));
         }
     }
 


### PR DESCRIPTION
Trying to fix CI PHPStan error with Symfony 8 run https://github.com/Sylius/Stack/actions/runs/28087707836/job/83157660332

But I'm not getting the same errors at all on my machine so still wip.
Wondering whether we should upgrade to higher PHPStan & Symfony extension version as well.

