### PR TITLE
[Docs] correct filename for custom grid field type codeblock

### DIFF
--- a/docs/grid/fields.md
+++ b/docs/grid/fields.md
@@ -396,7 +396,7 @@ Grids make it easy to define new types.
 All you need to do is create your own class implementing
 **FieldTypeInterface** and register it as a service.
 
-{% code title="src/Grid/FieldType.php" lineNumbers="true" %}
+{% code title="src/Grid/FieldType/CustomType.php" lineNumbers="true" %}
 
 ```php
 <?php


### PR DESCRIPTION
Hey,

First of all, thanks for the sylius stack project, this looks very promising and very developer friendly.

I think I spotted a tiny mistake in the grid docs, I updated the code block title based on the namespace but let me know if you wish something else