### PR TITLE
[BootstrapAdminUi] Add a body hookable to the create/update content composition

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,21 @@
+# UPGRADE
+
+## Unreleased
+
+### BootstrapAdminUi
+
+* The create/update content composition gained a `body` hookable that renders
+  the Tabler `.page-body` wrapper. The `form_error_alert` and `form` hookables
+  moved inside it:
+
+  | Before | After |
+  |---|---|
+  | `sylius_admin.common.create.content.form_error_alert` | `sylius_admin.common.create.content.body.form_error_alert` |
+  | `sylius_admin.common.create.content.form` | `sylius_admin.common.create.content.body.form` |
+  | `sylius_admin.common.update.content.form_error_alert` | `sylius_admin.common.update.content.body.form_error_alert` |
+  | `sylius_admin.common.update.content.form` | `sylius_admin.common.update.content.body.form` |
+
+  Hook configuration and templates targeting these hookables or their children
+  (e.g. `…content.form.sections.general`) must be retargeted accordingly. Apps
+  that overrode `shared/crud/common/content/form.html.twig` to add the missing
+  `.page-body` themselves should drop that override to avoid double wrapping.

--- a/src/BootstrapAdminUi/config/app/twig_hooks/common/create.php
+++ b/src/BootstrapAdminUi/config/app/twig_hooks/common/create.php
@@ -54,6 +54,12 @@ return static function (ContainerConfigurator $container): void {
                 'header' => [
                     'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/header.html.twig',
                 ],
+                'body' => [
+                    'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/body.html.twig',
+                ],
+            ],
+
+            'sylius_admin.common.create.content.body' => [
                 'form_error_alert' => [
                     'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/form_error_alert.html.twig',
                 ],
@@ -89,19 +95,19 @@ return static function (ContainerConfigurator $container): void {
                 ],
             ],
 
-            'sylius_admin.common.create.content.form' => [
+            'sylius_admin.common.create.content.body.form' => [
                 'sections' => [
                     'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/form/sections.html.twig',
                 ],
             ],
 
-            'sylius_admin.common.create.content.form.sections' => [
+            'sylius_admin.common.create.content.body.form.sections' => [
                 'general' => [
                     'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/form/sections/general.html.twig',
                 ],
             ],
 
-            'sylius_admin.common.create.content.form.sections.general' => [
+            'sylius_admin.common.create.content.body.form.sections.general' => [
                 'default' => [
                     'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/form/sections/general/default.html.twig',
                 ],

--- a/src/BootstrapAdminUi/config/app/twig_hooks/common/update.php
+++ b/src/BootstrapAdminUi/config/app/twig_hooks/common/update.php
@@ -54,6 +54,12 @@ return static function (ContainerConfigurator $container): void {
                 'header' => [
                     'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/header.html.twig',
                 ],
+                'body' => [
+                    'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/body.html.twig',
+                ],
+            ],
+
+            'sylius_admin.common.update.content.body' => [
                 'form_error_alert' => [
                     'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/form_error_alert.html.twig',
                 ],
@@ -91,19 +97,19 @@ return static function (ContainerConfigurator $container): void {
                 ],
             ],
 
-            'sylius_admin.common.update.content.form' => [
+            'sylius_admin.common.update.content.body.form' => [
                 'sections' => [
                     'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/form/sections.html.twig',
                 ],
             ],
 
-            'sylius_admin.common.update.content.form.sections' => [
+            'sylius_admin.common.update.content.body.form.sections' => [
                 'general' => [
                     'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/form/sections/general.html.twig',
                 ],
             ],
 
-            'sylius_admin.common.update.content.form.sections.general' => [
+            'sylius_admin.common.update.content.body.form.sections.general' => [
                 'default' => [
                     'template' => '@SyliusBootstrapAdminUi/shared/crud/common/content/form/sections/general/default.html.twig',
                 ],

--- a/src/BootstrapAdminUi/templates/shared/crud/common/content/body.html.twig
+++ b/src/BootstrapAdminUi/templates/shared/crud/common/content/body.html.twig
@@ -1,0 +1,3 @@
+<div class="page-body">
+    {% hook 'body' %}
+</div>

--- a/src/BootstrapAdminUi/tests/Functional/TemplatesTest.php
+++ b/src/BootstrapAdminUi/tests/Functional/TemplatesTest.php
@@ -38,4 +38,17 @@ final class TemplatesTest extends WebTestCase
         $this->assertAnySelectorTextSame('.nav-link-title', 'Dashboard'); // with "messages" domain
         $this->assertAnySelectorTextSame('.nav-link-title', 'Library'); // with "menu" domain
     }
+
+    public function testCreateTemplatePageStructure(): void
+    {
+        $this->client->request('GET', '/books/new');
+
+        $this->assertResponseIsSuccessful();
+        // Tabler layout: .page-body must be the .page-header's sibling — its
+        // top margin provides the header-to-content spacing.
+        $this->assertSelectorExists('.page-wrapper > .page-header');
+        $this->assertSelectorExists('.page-header + .page-body');
+        $this->assertSelectorExists('.page-body form');
+        $this->assertSelectorExists('.page-body form input[name="book_resource[name]"]');
+    }
 }


### PR DESCRIPTION
Create/update pages render no `.page-body`, so the form card sits glued to the sticky page header — the header-to-content spacing in Tabler comes from `.page-body`'s top margin against its `.page-header` sibling.

This adds a `body` hookable (rendering `.page-body`) to the create/update content composition; `form_error_alert` and `form` move under it.

**BC break:** hook customizations targeting `sylius_admin.common.{create,update}.content.form*` must retarget `…content.body.form*` — documented in the new `UPGRADE.md`.

| Before | After |
|---|---|
| <img width="1280" height="800" alt="before" src="https://github.com/user-attachments/assets/1acb67ec-4410-456f-8892-f63b32bf67eb" /> | <img width="1280" height="800" alt="after" src="https://github.com/user-attachments/assets/aa3907a8-fbe3-414a-9c04-f72de443dac1" /> |