### PR TITLE
Expand support for symfony/ux-twig-component and symfony/ux-live-component to v3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
         "symfony/twig-bundle": "^6.4 || ^7.4 || ^8.0",
         "symfony/ux-autocomplete": "^2.17",
         "symfony/ux-icons": "^2.20",
-        "symfony/ux-live-component": "^2.17",
-        "symfony/ux-twig-component": "^2.17",
+        "symfony/ux-live-component": "^2.17 || ^3.0",
+        "symfony/ux-twig-component": "^2.17 || ^3.0",
         "twig/twig": "^2.15 || ^3.0",
         "webmozart/assert": "^1.9"
     },

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -3,6 +3,8 @@ twig:
 
 twig_component:
     anonymous_template_directory: 'components/'
+    defaults:
+        App\Twig\Component\: 'components/'
 
 when@test:
     twig:

--- a/src/BootstrapAdminUi/composer.json
+++ b/src/BootstrapAdminUi/composer.json
@@ -17,7 +17,7 @@
         "symfony/stimulus-bundle": "^2.17",
         "symfony/ux-autocomplete": "^2.17",
         "symfony/ux-icons": "^2.20",
-        "symfony/ux-live-component": "^2.17"
+        "symfony/ux-live-component": "^2.17 || ^3.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.13 || ^3.0 || ^4.0",

--- a/src/TwigExtra/composer.json
+++ b/src/TwigExtra/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.1",
         "symfony/http-kernel": "^6.4 || ^7.4 || ^8.0",
         "symfony/twig-bundle": "^6.4 || ^7.4 || ^8.0",
-        "symfony/ux-twig-component": "^2.17"
+        "symfony/ux-twig-component": "^2.17 || ^3.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^6.1.0",

--- a/src/TwigHooks/composer.json
+++ b/src/TwigHooks/composer.json
@@ -21,8 +21,8 @@
         "symfony/expression-language": "^6.4 || ^7.4 || ^8.0",
         "symfony/http-kernel": "^6.4 || ^7.4 || ^8.0",
         "symfony/stopwatch": "^6.4 || ^7.4 || ^8.0",
-        "symfony/ux-live-component": "^2.17",
-        "symfony/ux-twig-component": "^2.17",
+        "symfony/ux-live-component": "^2.17 || ^3.0",
+        "symfony/ux-twig-component": "^2.17 || ^3.0",
         "symfony/twig-bundle": "^6.4 || ^7.4 || ^8.0",
         "twig/twig": "^2.15 || ^3.0",
         "webmozart/assert": "^1.9"


### PR DESCRIPTION
## Description:
Widens the version constraints for symfony/ux-twig-component and symfony/ux-live-component from ^2.17 to ^2.17 || ^3.0 in the root composer.json as well as the TwigHooks and TwigExtra package-level composer.json files, allowing Symfony UX 3.0 as a valid dependency alongside 2.17.